### PR TITLE
Switch to using mamba

### DIFF
--- a/config/workspace_dockerfile
+++ b/config/workspace_dockerfile
@@ -9,4 +9,4 @@ USER $NB_USER
 COPY requirements.txt /tmp/requirements.txt 
 
 # Install requirements.txt
-RUN conda install --file /tmp/requirements.txt
+RUN mamba install --file /tmp/requirements.txt


### PR DESCRIPTION
Mamba is a faster drop-in replacement for conda
Generated by mads-apply