### PR TITLE
Migrate to GitHub LFS

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,3 +1,0 @@
-[lfs]
-url ="http://gitlfs.michiganmads.org:8081/api/umsi-mads/mads_demo_course"
-


### PR DESCRIPTION

The MADS program is no longer using a custom LFS server.
This commit removes the config file pointing to that server,
which reverts this repo to using LFS on the GitHub server
hosting the rest of this repo.

Generated by mads-for-each, a tool for updating many courses at once.